### PR TITLE
Reconfigure the systemd service to refer the executable binaries from /usr/bin

### DIFF
--- a/resources/suite-bootstrapping.service
+++ b/resources/suite-bootstrapping.service
@@ -7,7 +7,7 @@ Requires=mosquitto.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/suite-bootstrapping -configFile /etc/suite-bootstrapping/config.json
+ExecStart=/usr/bin/suite-bootstrapping -configFile /etc/suite-bootstrapping/config.json
 Restart=always
 
 [Install]


### PR DESCRIPTION
[#5] Reconfigure the systemd service to refer the executable binaries from /usr/bin

- reconfigured

Signed-off-by: Georgi Boyvalenkov <Georgi.Boyvalenkov@bosch.io>