### PR TITLE
Ensure proper requests are sent when no prebootstrapping data is provided

### DIFF
--- a/internal/bootstrapping/agent.go
+++ b/internal/bootstrapping/agent.go
@@ -269,8 +269,8 @@ func (a *Agent) PublishRequest(requestID string, publisher message.Publisher) er
 	}
 
 	if !hasConfig {
-		payload.Hash = hex.EncodeToString(sha256.New().Sum(nil))
-		return a.publish(publisher, msg, correlationID, requestID, 0, headersOpts...)
+		// include only the request ID when no prebootstrapping data is available
+		return a.publish(publisher, msg.WithPayload(payload), correlationID, requestID, 0, headersOpts...)
 	}
 
 	hasher := sha256.New()

--- a/internal/bootstrapping/agent_test.go
+++ b/internal/bootstrapping/agent_test.go
@@ -271,7 +271,7 @@ func (s *BootstrappingSuite) TestSendRequestNoPreconfig() {
 	err = agent.PublishRequest(requestID, s.publisher)
 	require.NoError(s.T(), err)
 
-	checkPublished(s, requestID, false, hex.EncodeToString(sha256.New().Sum(nil)))
+	checkPublished(s, requestID, false, "")
 }
 
 func (s *BootstrappingSuite) TestSendRequestEmptyPreconfig() {
@@ -296,7 +296,7 @@ func (s *BootstrappingSuite) TestSendRequestEmptyPreconfig() {
 	err = agent.PublishRequest(requestID, s.publisher)
 	require.NoError(s.T(), err)
 
-	checkPublished(s, requestID, false, hex.EncodeToString(sha256.New().Sum(nil)))
+	checkPublished(s, requestID, false, "")
 }
 
 // Handle response tests
@@ -586,14 +586,13 @@ func assertRequestEnvelope(
 ) {
 	assert.EqualValues(s.T(), requestTopic, actual.Topic.String(), index)
 	assert.EqualValues(s.T(), requestPath, actual.Path, index)
-	if actual.Value != nil {
-		actualData := &bs.RequestData{}
-		extractAsData(s.T(), actual.Value, actualData)
 
-		require.Equal(s.T(), requestID, actualData.ID)
-		assert.Equal(s.T(), hasChunk, len(actualData.Chunk) > 0, index)
-		assert.Equal(s.T(), hash, actualData.Hash, index)
-	}
+	actualData := &bs.RequestData{}
+	extractAsData(s.T(), actual.Value, actualData)
+
+	require.Equal(s.T(), requestID, actualData.ID)
+	assert.Equal(s.T(), hasChunk, len(actualData.Chunk) > 0, index)
+	assert.Equal(s.T(), hash, actualData.Hash, index)
 }
 
 func responseMsg(deviceID string, payload interface{}, required bool) *message.Message {


### PR DESCRIPTION
[#11] Improper request data sent when no prebootstrapping data is provided

Fixes applied:
* Ensured the request ID is always sent
* Ensured compliant hashes handling in the requests sent
* Updated TCs accordingly:
  * Require an empty hash when no prebootstrapping data is configured
  * Always require a request ID (thus, a non-empty Ditto message value) in the requests

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>