### PR TITLE
Apply the new Eclipse Kanto project license scheme

### DIFF
--- a/cmd/bootstrapping/main.go
+++ b/cmd/bootstrapping/main.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package main
 

--- a/internal/bootstrapping/agent.go
+++ b/internal/bootstrapping/agent.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package bootstrapping
 

--- a/internal/bootstrapping/agent_test.go
+++ b/internal/bootstrapping/agent_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package bootstrapping_test
 

--- a/internal/bootstrapping/errors.go
+++ b/internal/bootstrapping/errors.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package bootstrapping
 

--- a/internal/bootstrapping/errors_test.go
+++ b/internal/bootstrapping/errors_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package bootstrapping_test
 

--- a/internal/bootstrapping/file_utils.go
+++ b/internal/bootstrapping/file_utils.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package bootstrapping
 

--- a/internal/bootstrapping/file_utils_test.go
+++ b/internal/bootstrapping/file_utils_test.go
@@ -5,9 +5,10 @@
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License 2.0 which is available at
-// http://www.eclipse.org/legal/epl-2.0
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
 //
-// SPDX-License-Identifier: EPL-2.0
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 
 package bootstrapping_test
 


### PR DESCRIPTION
[#13] Apply the new Eclipse Kanto project license scheme
- updated copyright header in source files

Signed-off-by: Gabriela Yoncheva <Gabriela.Yoncheva@bosch.io>