### PR TITLE
Ensure no response is sent to one way commands

### DIFF
--- a/internal/bootstrapping/agent.go
+++ b/internal/bootstrapping/agent.go
@@ -372,7 +372,7 @@ func (a *Agent) handleResponseMessage(msg *message.Message) (string, bool, *Mess
 		if rspMsg.Path == bsResponsePath {
 			payload, err := json.Marshal(rspMsg.Value)
 			if err != nil {
-				return "", respReq, NewMessageParameterInvalidError(), errors.Wrapf(err, "invalid payload: %v", rspMsg.Value)
+				return correlationID, respReq, NewMessageParameterInvalidError(), errors.Wrapf(err, "invalid payload: %v", rspMsg.Value)
 			}
 
 			var response ResponseData

--- a/internal/bootstrapping/agent.go
+++ b/internal/bootstrapping/agent.go
@@ -404,9 +404,13 @@ func (a *Agent) handleResponseMessage(msg *message.Message) (string, bool, *Mess
 
 				return correlationID, respReq, msgError, err
 			}
+			return correlationID, respReq, nil, nil
 		}
+		return correlationID, respReq, NewMessageParameterInvalidError(),
+			errors.New("response with wrong path is not handled")
 	}
-	return correlationID, respReq, nil, nil
+	return correlationID, respReq, NewMessageParameterInvalidError(),
+		errors.New("response with unknown device ID is not handled")
 }
 
 func (a *Agent) addRequestResponse(data ResponseData, msgUID, correlationID string) (*MessageError, error) {

--- a/internal/bootstrapping/agent.go
+++ b/internal/bootstrapping/agent.go
@@ -370,7 +370,7 @@ func (a *Agent) handleResponseMessage(msg *message.Message) (string, *MessageErr
 	respReq := rspMsg.Headers.IsResponseRequired()
 
 	var replyToID string
-	
+
 	if respReq && len(correlationID) > 0 {
 		replyToID = correlationID
 	}


### PR DESCRIPTION
[#20] Suite bootstrapping service gets disconnected after receiving an error response

- ensured no reply is sent to messages that don't require a response

Signed-off-by: Gabriela Yoncheva <Gabriela.Yoncheva@bosch.io>