### PR TITLE
Add coverage label

### DIFF
--- a/.github/workflows/generate-coverage-report.yaml
+++ b/.github/workflows/generate-coverage-report.yaml
@@ -1,0 +1,12 @@
+name: Create Coverage
+
+on: 
+  push:
+    branches:
+    - main
+
+jobs:
+  generate-coverage-report:
+    uses: eclipse-kanto/kanto/.github/workflows/coverage-template.yaml@main
+    with: 
+      coverage-command: go test ./... -coverprofile=coverage.out -covermode count

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-![Kanto logo](https://github.com/eclipse-kanto/kanto/raw/main/logo/kanto.svg)
+[![Kanto logo](https://github.com/eclipse-kanto/kanto/raw/main/logo/kanto.svg)](https://eclipse.dev/kanto/)
 
 # Eclipse Kanto - Suite Bootstrapping
+
+[![Coverage](https://github.com/eclipse-kanto/suite-bootstrapping/wiki/coverage.svg)](#)
 
 The suite bootstrapping provides a mechanism for automatic provisioning of devices for connecting to a target suite.
 Devices can be shipped with a uniform clean setup without knowing the target suite subscription or tenancy


### PR DESCRIPTION
[#38] Added coverage label and changed kanto logo to open the main page of the site.

Signed-off-by: Daniel Milchev [fixed-term.daniel.milchev@bosch.io](mailto:fixed-term.daniel.milchev@bosch.io)